### PR TITLE
Fix for unresponsive frontend display

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,13 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  webpack: (config, _) => ({
+    ...config,
+    watchOptions: {
+      ...config.watchOptions,
+      poll: 800,
+      aggregateTimeout: 300,
+    },})
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
I ran into the problem that localhost didn't show changes I made in the next.js files without restarting your frontend docker container.
This is a suggestion to fix this problem. It adds sort of a listener for changes in the next dev environment in next.config.js (It might not work for production environments.)